### PR TITLE
rework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,5 @@ RUN \
 # 3000: Axon publisher (notifies of new inbound calls)
 # 3001: Axon subscriber (submit commands to the calls)
 EXPOSE 8021 3000 3001
-CMD ["npm","start"]
+ENTRYPOINT ["node","server.js"]
+CMD ["{}"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gabby-potato",
   "docker_name": "shimaore/gabby-potato",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "An automated endpoint for SIP testing",
   "scripts": {
     "test": "mocha",

--- a/server.coffee.md
+++ b/server.coffee.md
@@ -19,6 +19,10 @@
         fsconf: "#{cwd}/conf/freeswitch.xml"
         log: "#{cwd}/log"
 
+      try
+        cmd = JSON.parse process.argv[2]
+        cfg = Object.assign cfg, cmd if cmd?
+
 Generate configuration file
 
       xml = (require './conf') cfg

--- a/test/private-args.coffee.md
+++ b/test/private-args.coffee.md
@@ -9,7 +9,7 @@
     sleep = (timeout) ->
       new Promise (resolve) -> setTimeout resolve, timeout
 
-    describe 'When starting the docker image', ->
+    describe 'When starting the docker image with arguments', ->
       @timeout 20000
       started = false
 
@@ -20,19 +20,16 @@
           [],
           if process.env.DEBUG_FS then [process.stdout,process.stderr] else null,
           {
-            Env:[
-              "USERNAME=foo"
-              "PASSWORD=bar"
-              "DOMAIN=phone.example.net"
-              "HOSTNAME=test.example.net"
-              "EXPIRE=1800"
-              "DEBUG=*"
+            Cmd: [ JSON.stringify
+              username:'foo'
+              password:'bar'
+              domain:'phone.example.net'
             ]
             HostConfig:
               PortBindings:
-                '8021/tcp': [HostPort: '8021']
-                '3000/tcp': [HostPort: '3000']
-                '3001/tcp': [HostPort: '3001']
+                '8021/tcp': [HostPort: '9021']
+                '3000/tcp': [HostPort: '4000']
+                '3001/tcp': [HostPort: '4001']
             Tty: false
           },
           (error,data,container) ->
@@ -57,7 +54,7 @@
           await @exit().catch -> yes
           @end()
           done()
-        .connect 8021
+        .connect 9021
         return
 
       it 'should stop', (done) ->
@@ -68,5 +65,5 @@
           done()
         .on 'error', (error) ->
           debug "Caught #{error}"
-        .connect 8021
+        .connect 9021
         return


### PR DESCRIPTION
- simplify by giving direct access to the Event Socket
- use Axon instead of socket.io (only for inbound calls)
- Docker image usable as a service